### PR TITLE
Replace ApiClientTv usage

### DIFF
--- a/app/src/main/java/com/example/daawahtv/TvShowDetailsActivity.kt
+++ b/app/src/main/java/com/example/daawahtv/TvShowDetailsActivity.kt
@@ -69,7 +69,7 @@ class TvShowDetailsActivity : AppCompatActivity() {
 
     private fun loadTvShowDetails(programId: Long) {
         Toast.makeText(this, "جاري تحميل التفاصيل...", Toast.LENGTH_SHORT).show()
-        ApiClientTv.tvShowApiService.getTvShowDetails(programId).enqueue(object : Callback<TvShowDetailsResponse> {
+        ApiClient.getTvShowApiService().getTvShowDetails(programId).enqueue(object : Callback<TvShowDetailsResponse> {
             override fun onResponse(call: Call<TvShowDetailsResponse>, response: Response<TvShowDetailsResponse>) {
                 if (response.isSuccessful && response.body()?.status == true) {
                     val details = response.body()!!.data.details
@@ -100,7 +100,7 @@ class TvShowDetailsActivity : AppCompatActivity() {
         val limit = 100
         Log.d("Episodes", "Requesting episodes offset=$offset, limit=$limit")
         Toast.makeText(this, "جاري تحميل الحلقات...", Toast.LENGTH_SHORT).show()
-        ApiClientTv.tvShowApiService.getSeasonEpisodes(programId, seasonIndex, limit, offset)
+        ApiClient.getTvShowApiService().getSeasonEpisodes(programId, seasonIndex, limit, offset)
             .enqueue(object : Callback<SeasonResponse> {
             override fun onResponse(call: Call<SeasonResponse>, response: Response<SeasonResponse>) {
                 if (response.isSuccessful && response.body()?.status == true) {
@@ -128,7 +128,7 @@ class TvShowDetailsActivity : AppCompatActivity() {
 
     private fun loadVideoUrlForEpisode(episodeId: Long, position: Int) {
         Toast.makeText(this, "جاري تحميل الحلقة...", Toast.LENGTH_SHORT).show()
-        ApiClientTv.tvShowApiService.getEpisodeDetails(episodeId.toInt())
+        ApiClient.getTvShowApiService().getEpisodeDetails(episodeId.toInt())
             .enqueue(object : Callback<EpisodeDetailsResponse> {
                 @OptIn(UnstableApi::class)
                 override fun onResponse(call: Call<EpisodeDetailsResponse>, response: Response<EpisodeDetailsResponse>) {

--- a/app/src/main/java/com/example/daawahtv/YouTubePlayerActivity.kt
+++ b/app/src/main/java/com/example/daawahtv/YouTubePlayerActivity.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import android.webkit.JavascriptInterface
 import android.widget.Toast
 import com.example.daawahtv.PlaybackPositionManager
-import com.example.daawahtv.network.ApiClientTv
+import com.example.daawahtv.network.ApiClient
 import com.example.daawahtv.network.EpisodeDetailsResponse
 import java.util.regex.Pattern
 
@@ -125,7 +125,7 @@ class YouTubePlayerActivity : AppCompatActivity() {
         PlaybackPositionManager.savePosition(this, currentEpisodeId, 0)
         currentEpisodeId = nextId
         Toast.makeText(this, "تشغيل الحلقة التالية...", Toast.LENGTH_SHORT).show()
-        ApiClientTv.tvShowApiService.getEpisodeDetails(nextId.toInt())
+        ApiClient.getTvShowApiService().getEpisodeDetails(nextId.toInt())
             .enqueue(object : retrofit2.Callback<EpisodeDetailsResponse> {
                 override fun onResponse(
                     call: retrofit2.Call<EpisodeDetailsResponse>,


### PR DESCRIPTION
## Summary
- replace legacy ApiClientTv usages with ApiClient
- remove unused ApiClientTv import

## Testing
- `bash ./gradlew tasks --all`
- `bash ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883cbe41fbc832f9686debd335d94b4