### PR TITLE
Fix EpisodeItem import in PlaybackActivity

### DIFF
--- a/app/src/main/java/com/example/daawahtv/PlaybackActivity.kt
+++ b/app/src/main/java/com/example/daawahtv/PlaybackActivity.kt
@@ -16,14 +16,12 @@ import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.ui.PlayerView
-import com.example.daawahtv.EpisodeItem
 import com.example.daawahtv.network.ApiClient
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import com.example.daawahtv.network.ApiClient
 import com.example.daawahtv.network.TvShowApiService
-import com.example.daawahtv.model.EpisodeItem
+import com.example.daawahtv.network.EpisodeItem
 
 @UnstableApi
 class PlaybackActivity : Activity() {


### PR DESCRIPTION
## Summary
- cleanup imports in `PlaybackActivity.kt` by removing duplicates and referencing the correct `EpisodeItem` type

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883d474947c832f9151113e584511df