### PR TITLE
Fix network response signatures

### DIFF
--- a/app/src/main/java/com/example/daawahtv/network/ApiService.kt
+++ b/app/src/main/java/com/example/daawahtv/network/ApiService.kt
@@ -4,14 +4,14 @@ import retrofit2.Response // تأكد من استيراد Response
 import retrofit2.http.GET
 import retrofit2.http.Query
 import retrofit2.http.Path
-import com.example.daawahtv.network.EpisodesResponse // تم إضافة هذا الاستيراد
+import com.example.daawahtv.network.EpisodeItem
 
 interface ApiService {
     // اجعل الدالة suspend
     @GET("dashboard/home")
-    suspend fun getHomeContent(): HomeResponse // لم تعد تُرجع Call، بل HomeResponse مباشرة
+    suspend fun getHomeContent(): Response<HomeResponse> // تعديل لتعيد Response
 
     // مثال لدالة أخرى، اجعلها suspend أيضاً
     @GET("episodes")
-    suspend fun getEpisodesByProgram(@Query("program_id") programId: Long): EpisodesResponse
+    suspend fun getEpisodesByProgram(@Query("program_id") programId: Long): Response<List<EpisodeItem>>
 }

--- a/app/src/main/java/com/example/daawahtv/repository/NetworkRepository.kt
+++ b/app/src/main/java/com/example/daawahtv/repository/NetworkRepository.kt
@@ -36,8 +36,7 @@ class NetworkRepository @Inject constructor(
     }
 
     // ✅ جلب الحلقات المرتبطة ببرنامج معيّن (حسب البرنامج وليس الموسم)
-    suspend fun getEpisodesByProgram(programId: Long): List<EpisodeItem> = withContext(Dispatchers.IO) {
-        apiService.getEpisodesByProgram(programId).execute().body()
-            ?: emptyList()
+    suspend fun getEpisodesByProgram(programId: Long): Response<List<EpisodeItem>> = withContext(Dispatchers.IO) {
+        apiService.getEpisodesByProgram(programId)
     }
 }


### PR DESCRIPTION
## Summary
- update `ApiService` functions to return `Response` types
- adjust `NetworkRepository` to match new API

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883d9b8b318832fa3f1d73a6e7de982